### PR TITLE
Fixup no-std support so the crate builds with only alloc feature

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,12 @@ jobs:
       - name: Test with no default features
         run: cargo test --no-default-features
 
+      - name: Test with only alloc feature
+        run: cargo test --no-default-features --features alloc
+
+      - name: Test with only alloc + std features
+        run: cargo test --no-default-features --features alloc,std
+
   build-msrv:
     name: Build (MSRV)
     runs-on: ubuntu-latest

--- a/src/format/write.rs
+++ b/src/format/write.rs
@@ -3,6 +3,8 @@
 //!
 //! [`std::io::Write`]: <https://doc.rust-lang.org/std/io/trait.Write.html>
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 use core::fmt;
 
 use crate::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(not(feature = "std"), no_std)]
 #![forbid(unsafe_code)]
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
@@ -107,6 +106,13 @@
 //! the previous year.
 
 #![doc(html_root_url = "https://docs.rs/strftime-ruby/0.1.0")]
+#![no_std]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 // Ensure code blocks in `README.md` compile
 #[cfg(all(doctest, feature = "std"))]
@@ -245,6 +251,8 @@ pub mod buffered {
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub mod bytes {
+    use alloc::vec::Vec;
+
     use super::{Error, Time};
     use crate::format::TimeFormatter;
 
@@ -285,6 +293,9 @@ pub mod bytes {
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub mod string {
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
     use super::{Error, Time};
     use crate::format::TimeFormatter;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -848,6 +848,8 @@ fn test_format_large_width() {
 #[cfg(feature = "alloc")]
 #[test]
 fn test_format_formatted_string_too_large() {
+    use alloc::vec::Vec;
+
     let time = MockTime::new(1970, 1, 1, 0, 0, 0, 0, 4, 1, 0, false, 0, "");
 
     let mut buf = Vec::new();


### PR DESCRIPTION
- Make crate unconditionally `#![no_std]` (I find it makes it easier to avoid mistakes like this by always having to `use` symbols).
- Add `extern crate alloc` when the `alloc` feature is enabled.
- Add `extern crate std` when the `std` feature is enabled.
- Add `Vec` import to `crate::format::write` module.
- Add steps to CI to test with no default features + alloc and no default features + alloc,std