### PR TITLE
Use fallible allocation APIs

### DIFF
--- a/src/format/write.rs
+++ b/src/format/write.rs
@@ -82,6 +82,7 @@ impl Write for &mut [u8] {
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl Write for Vec<u8> {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
+        self.try_reserve(buf.len())?;
         self.extend_from_slice(buf);
         Ok(buf.len())
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,6 +3,7 @@ use crate::{Error, Time};
 
 include!("mock.rs.in");
 
+#[allow(clippy::needless_pass_by_value)] // for ergonomics
 fn check_format(time: &impl Time, format: &str, expected: Result<&str, Error>) {
     const SIZE: usize = 100;
     let mut buf = [0u8; SIZE];


### PR DESCRIPTION
For the implementation of `Write` for `Vec<u8>`, use `Vec::try_reserve`
to try and allocate memory before copying a slice into the `Vec`. If a
`TryReserveError` is returned, bubble that up to the caller instead of
letting `alloc` do a process abort.

If an allocation fails, return `Error::OutOfMemory`.

This commit removes `derive(Copy)` from the error type in this crate
because the inner `TryReserveError` in the `OutOfMemory` variant is not
`Copy`.