### PR TITLE
Remove unused quickcheck dev dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,6 @@ alloc = []
 bitflags = "1.3"
 
 [dev-dependencies]
-# Property testing for interner getters and setters.
-quickcheck = { version = "1.0.3", default-features = false }
-quickcheck_macros = "1.0.0"
 
 # Check that crate versions are properly updated in documentation and code when
 # bumping the version.


### PR DESCRIPTION
This is a copy and paste oversight from when I bootstrapped the cargo manifest from intaglio.