### PR TITLE
Solve spurious network errors in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,7 @@ jobs:
     env:
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: 1
+      CARGO_NET_GIT_FETCH_WITH_CLI: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -65,6 +66,7 @@ jobs:
       CARGO_INCREMENTAL: 0
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: 1
+      CARGO_NET_GIT_FETCH_WITH_CLI: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -97,6 +99,7 @@ jobs:
     env:
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: 1
+      CARGO_NET_GIT_FETCH_WITH_CLI: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
> Run cargo build --verbose
>     Updating crates.io index
> warning: spurious network error (2 tries remaining): SecureTransport error: connection closed via error; class=Net (12)
> warning: spurious network error (1 tries remaining): SecureTransport error: connection closed via error; class=Net (12)
> error: failed to get `version-sync` as a dependency of package `strftime-ruby v0.1.0 (/Users/runner/work/strftime-ruby/strftime-ruby)`
> 
> Caused by:
>   failed to load source for dependency `version-sync`
> 
> Caused by:
>   Unable to update registry `crates-io`
> 
> Caused by:
>   failed to fetch `https://github.com/rust-lang/crates.io-index`
> 
> Caused by:
>   network failure seems to have happened
>   if a proxy or similar is necessary `net.git-fetch-with-cli` may help here
>   https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
> 
> Caused by:
>   SecureTransport error: connection closed via error; class=Net (12)
> Error: Process completed with exit code 101.