### PR TITLE
Use `aws s3 sync --delete` when uploading coverage results to S3

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload archives to S3
         run: |
-          aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --recursive --delete --sse AES256 --exclude '*' --include '*.svg' --content-type 'image/svg+xml'
-          aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --recursive --delete --sse AES256 --exclude '*' --include '*.html' --content-type 'text/html'
-          aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --recursive --delete --sse AES256 --exclude '*' --include '*.json' --content-type 'application/json'
-          aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --recursive --delete --sse AES256 --include '*' --exclude '*.svg' --exclude '*.html' --exclude '*.json'
+          aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --delete --sse AES256 --exclude '*' --include '*.svg' --content-type 'image/svg+xml'
+          aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --delete --sse AES256 --exclude '*' --include '*.html' --content-type 'text/html'
+          aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --delete --sse AES256 --exclude '*' --include '*.json' --content-type 'application/json'
+          aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --delete --sse AES256 --include '*' --exclude '*.svg' --exclude '*.html' --exclude '*.json'

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Upload archives to S3
         if: github.ref == 'refs/heads/trunk'
         run: |
-          aws s3 cp target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --recursive --sse AES256 --exclude '*' --include '*.svg' --content-type 'image/svg+xml'
-          aws s3 cp target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --recursive --sse AES256 --exclude '*' --include '*.html' --content-type 'text/html'
-          aws s3 cp target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --recursive --sse AES256 --exclude '*' --include '*.json' --content-type 'application/json'
-          aws s3 cp target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --recursive --sse AES256 --include '*' --exclude '*.svg' --exclude '*.html' --exclude '*.json'
+          aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --recursive --delete --sse AES256 --exclude '*' --include '*.svg' --content-type 'image/svg+xml'
+          aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --recursive --delete --sse AES256 --exclude '*' --include '*.html' --content-type 'text/html'
+          aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --recursive --delete --sse AES256 --exclude '*' --include '*.json' --content-type 'application/json'
+          aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --recursive --delete --sse AES256 --include '*' --exclude '*.svg' --exclude '*.html' --exclude '*.json'

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -53,15 +53,18 @@ jobs:
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@master
+        if: github.ref == 'refs/heads/trunk'
         with:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::447522982029:role/gha-strftime-ruby-s3-backup-20220817011212567800000002
           role-session-name: GitHubActionsSession@codecov
 
       - name: Show AWS caller identity
+        if: github.ref == 'refs/heads/trunk'
         run: aws sts get-caller-identity
 
       - name: Upload archives to S3
+        if: github.ref == 'refs/heads/trunk'
         run: |
           aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --delete --sse AES256 --exclude '*' --include '*.svg' --content-type 'image/svg+xml'
           aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --delete --sse AES256 --exclude '*' --include '*.html' --content-type 'text/html'

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -29,8 +29,14 @@ jobs:
           override: true
           components: llvm-tools-preview
 
-      - name: Install grcov
-        run: cargo install grcov
+      - name: Setup grcov
+        run: |
+          release_url="$(curl \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/mozilla/grcov/releases | \
+            jq -r '.[0].assets | map(select(.browser_download_url | test(".*x86_64-unknown-linux-musl.tar.bz2$"))) | .[0].browser_download_url')"
+
+          curl -sL "$release_url" | sudo tar xvj -C /usr/local/bin/
 
       - name: Generate coverage
         env:

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -47,18 +47,15 @@ jobs:
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@master
-        if: github.ref == 'refs/heads/trunk'
         with:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::447522982029:role/gha-strftime-ruby-s3-backup-20220817011212567800000002
           role-session-name: GitHubActionsSession@codecov
 
       - name: Show AWS caller identity
-        if: github.ref == 'refs/heads/trunk'
         run: aws sts get-caller-identity
 
       - name: Upload archives to S3
-        if: github.ref == 'refs/heads/trunk'
         run: |
           aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --recursive --delete --sse AES256 --exclude '*' --include '*.svg' --content-type 'image/svg+xml'
           aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --recursive --delete --sse AES256 --exclude '*' --include '*.html' --content-type 'text/html'


### PR DESCRIPTION
This handles the case where files are moved in the source tree.

See:

- https://github.com/artichoke/strftime-ruby/pull/37#issuecomment-1217555467
- https://github.com/artichoke/project-infrastructure/issues/334
- https://github.com/artichoke/project-infrastructure/pull/335

Speed up the build by downoading pre-compiled `grcov` binaries from https://github.com/mozilla/grcov/releases.