### PR TITLE
Add note about implementing `Time` trait to crate-level documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,13 @@
 //! %<flags><width><modifier><conversion>
 //! ```
 //!
+//! # Usage
+//!
+//! The various `strftime` functions in this crate take a generic _time_
+//! parameter that implements the [`Time`] trait.
+//!
+//! # Format Specifiers
+//!
 //! ## Flags
 //!
 //! | Flag | Description                                                                            |


### PR DESCRIPTION
Also add a header for the section on format specifiers.

Noticed this while reviewing the docs as part of the tasks in https://github.com/artichoke/strftime-ruby/issues/42.