### PR TITLE
Provide a core::fmt::Write strftime implementation

### DIFF
--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -17,6 +17,7 @@ use utils::{Cursor, SizeLimiter};
 use week::{iso_8601_year_and_week_number, week_number, WeekStart};
 use write::Write;
 
+pub(crate) use write::FmtWrite;
 #[cfg(feature = "std")]
 pub(crate) use write::IoWrite;
 

--- a/src/format/write.rs
+++ b/src/format/write.rs
@@ -6,6 +6,7 @@
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 use core::fmt;
+use core::str;
 
 use crate::Error;
 
@@ -73,6 +74,26 @@ impl Write for &mut [u8] {
         a.copy_from_slice(&data[..size]);
         *self = b;
         Ok(size)
+    }
+}
+
+pub(crate) struct FmtWrite<'a> {
+    /// Inner writer.
+    inner: &'a mut dyn fmt::Write,
+}
+
+impl<'a> FmtWrite<'a> {
+    pub(crate) fn new(inner: &'a mut dyn fmt::Write) -> Self {
+        Self { inner }
+    }
+}
+
+impl Write for FmtWrite<'_> {
+    fn write(&mut self, data: &[u8]) -> Result<usize, Error> {
+        let data =
+            str::from_utf8(data).expect("strftime::fmt::strftime should only receive UTF-8 data");
+        self.inner.write_str(data)?;
+        Ok(data.len())
     }
 }
 

--- a/src/format/write.rs
+++ b/src/format/write.rs
@@ -77,23 +77,29 @@ impl Write for &mut [u8] {
     }
 }
 
+/// Wrapper for a [`core::fmt::Write`] writer.
 pub(crate) struct FmtWrite<'a> {
     /// Inner writer.
     inner: &'a mut dyn fmt::Write,
 }
 
 impl<'a> FmtWrite<'a> {
+    /// Construct a new `FmtWrite`.
     pub(crate) fn new(inner: &'a mut dyn fmt::Write) -> Self {
         Self { inner }
     }
 }
 
+/// Write is implemented for `FmtWrite` by writing to its inner writer.
 impl Write for FmtWrite<'_> {
     fn write(&mut self, data: &[u8]) -> Result<usize, Error> {
-        let data =
-            str::from_utf8(data).expect("strftime::fmt::strftime should only receive UTF-8 data");
+        let data = str::from_utf8(data).expect("FmtWrite should only receive UTF-8 data");
         self.inner.write_str(data)?;
         Ok(data.len())
+    }
+
+    fn write_fmt(&mut self, fmt_args: fmt::Arguments<'_>) -> Result<(), Error> {
+        Ok(self.inner.write_fmt(fmt_args)?)
     }
 }
 
@@ -171,5 +177,15 @@ mod tests {
         write!(writer, "{}", 1).unwrap();
 
         assert_eq!(buf, *b"ok1");
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn test_fmt_write() {
+        use alloc::string::String;
+
+        let mut buf = String::new();
+        write!(FmtWrite::new(&mut buf), "{}", 1).unwrap();
+        assert_eq!(buf, "1");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,7 @@ impl std::error::Error for Error {
 }
 
 impl From<core::fmt::Error> for Error {
-    fn from(_err: core::fmt::Error) -> Self {
+    fn from(_: core::fmt::Error) -> Self {
         Self::FmtError
     }
 }
@@ -317,16 +317,16 @@ pub mod buffered {
     }
 }
 
-/// Provides a `strftime` implementation using a format string with
-/// arbitrary bytes, writing to a [`core::fmt::Write`] object.
+/// Provides a `strftime` implementation using a UTF-8 format string, writing to
+/// a [`core::fmt::Write`] object.
 pub mod fmt {
     use core::fmt::Write;
 
     use super::{Error, Time};
     use crate::format::{FmtWrite, TimeFormatter};
 
-    /// Format a _time_ implementation with the specified format string, writing
-    /// to the provided [`core::fmt::Write`] object.
+    /// Format a _time_ implementation with the specified UTF-8 format string,
+    /// writing to the provided [`core::fmt::Write`] object.
     ///
     /// See the [crate-level documentation](crate) for a complete description of
     /// possible format specifiers.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,8 +134,6 @@ mod format;
 #[cfg(test)]
 mod tests;
 
-use core::fmt;
-
 /// Error type returned by the `strftime` functions.
 #[derive(Debug)]
 // To ensure the API is the same for all feature combinations, do not derive
@@ -171,8 +169,8 @@ pub enum Error {
     IoError(std::io::Error),
 }
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Error::InvalidTime => f.write_str("invalid time"),
             Error::InvalidFormatString => f.write_str("invalid format string"),
@@ -196,6 +194,12 @@ impl std::error::Error for Error {
             Self::IoError(inner) => Some(inner),
             _ => None,
         }
+    }
+}
+
+impl From<core::fmt::Error> for Error {
+    fn from(_err: core::fmt::Error) -> Self {
+        Self::FmtError
     }
 }
 
@@ -310,6 +314,53 @@ pub mod buffered {
         let remaining_len = cursor.len();
 
         Ok(&mut buf[..len - remaining_len])
+    }
+}
+
+/// Provides a `strftime` implementation using a format string with
+/// arbitrary bytes, writing to a [`core::fmt::Write`] object.
+pub mod fmt {
+    use core::fmt::Write;
+
+    use super::{Error, Time};
+    use crate::format::{FmtWrite, TimeFormatter};
+
+    /// Format a _time_ implementation with the specified format string, writing
+    /// to the provided [`core::fmt::Write`] object.
+    ///
+    /// See the [crate-level documentation](crate) for a complete description of
+    /// possible format specifiers.
+    ///
+    /// # Allocations
+    ///
+    /// This `strftime` implementation makes no heap allocations on its own, but
+    /// the provided writer may allocate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use strftime::fmt::strftime;
+    /// use strftime::Time;
+    ///
+    /// // Not shown: create a time implementation with the year 1970
+    /// // let time = ...;
+    /// # include!("mock.rs.in");
+    /// # fn main() -> Result<(), strftime::Error> {
+    /// # let time = MockTime { year: 1970, ..Default::default() };
+    /// assert_eq!(time.year(), 1970);
+    ///
+    /// let mut buf = String::new();
+    /// strftime(&time, "%Y", &mut buf)?;
+    /// assert_eq!(buf, "1970");
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Can produce an [`Error`](crate::Error) when the formatting fails.
+    pub fn strftime(time: &impl Time, format: &str, buf: &mut dyn Write) -> Result<(), Error> {
+        TimeFormatter::new(time, format).fmt(&mut FmtWrite::new(buf))
     }
 }
 

--- a/src/tests/error.rs
+++ b/src/tests/error.rs
@@ -44,6 +44,13 @@ fn test_error_from_io_error() {
     assert!(matches!(io_error.into(), Error::IoError(_)));
 }
 
+#[test]
+fn test_error_from_fmt_error() {
+    use crate::Error;
+
+    assert!(matches!(core::fmt::Error.into(), Error::FmtError));
+}
+
 #[cfg(feature = "std")]
 #[test]
 fn test_error_source_returns_inner_error() {


### PR DESCRIPTION
This implementation uses the same approach as in #49 for
`std::io::Write` and applies it to `core::fmt::Write`. An adapter type
that takes an inner `&mut dyn core::fmt::Write` has
`crate::format::Write` implemented for it.

Much like the implementation of `strftime::string::strftime` which
asserts UTF-8 well-formedness with a call to `expect`, the
implementation of `crate::format::Write` for `FmtWrite` calls
`str::from_utf8(..).expect(..)` on the byte slice passed to it. This
UTF-8 slice is then passed to `core::fmt::Write::write_str`.

This call to expect is not expected to panic for the same reasons why
the call to expect is safe for `strftime::string::strftime`.