### PR TITLE
Make mod-level docs have consistent structure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,8 +262,8 @@ const _: Option<&dyn Time> = None;
 /// [`Time#asctime`]: <https://ruby-doc.org/core-3.1.2/Time.html#method-i-asctime>
 pub const ASCTIME_FORMAT_STRING: &str = "%c";
 
-/// Provides a buffered `strftime` implementation using a format string with
-/// arbitrary bytes.
+/// Provides `strftime` implementation using a format string with arbitrary
+/// bytes, writing to a provided byte slice.
 pub mod buffered {
     use super::{Error, Time};
     use crate::format::TimeFormatter;
@@ -364,7 +364,10 @@ pub mod fmt {
     }
 }
 
-/// Provides a `strftime` implementation using a format string with arbitrary bytes.
+/// Provides a `strftime` implementation using a format string with arbitrary
+/// bytes, writing to a newly allocated [`Vec`].
+///
+/// [`Vec`]: alloc::vec::Vec
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub mod bytes {
@@ -413,7 +416,10 @@ pub mod bytes {
     }
 }
 
-/// Provides a `strftime` implementation using a UTF-8 format string.
+/// Provides a `strftime` implementation using a UTF-8 format string, writing to
+/// a newly allocated [`String`].
+///
+/// [`String`]: alloc::string::String
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub mod string {
@@ -463,8 +469,8 @@ pub mod string {
     }
 }
 
-/// Provides a `strftime` implementation using a format string with
-/// arbitrary bytes, writing to a [`std::io::Write`] object.
+/// Provides a `strftime` implementation using a format string with arbitrary
+/// bytes, writing to a [`std::io::Write`] object.
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod io {


### PR DESCRIPTION
Ensure the writer/destination is always specified in the mod-level docs for the various `strftime` functions.

## Before

<img width="364" alt="Screen Shot 2022-08-19 at 9 54 28 AM" src="https://user-images.githubusercontent.com/860434/185669497-6a6605f0-3283-4413-9f85-9e8f7fb2efc9.png">

## After

<img width="364" alt="Screen Shot 2022-08-19 at 9 53 56 AM" src="https://user-images.githubusercontent.com/860434/185669451-d1c6b8cd-b08d-41f7-9406-e6b3718a6b0e.png">