### PR TITLE
Clarify license of vendored Ruby C code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ homepage = "https://github.com/artichoke/strftime-ruby"
 description = "Ruby `Time#strftime` parser and formatter"
 keywords = ["ruby", "strftime", "time"]
 categories = ["date-and-time", "no-std", "parser-implementations", "value-formatting"]
-include = ["src/**/*", "tests/**/*", "vendor/**/*", "LICENSE", "README.md"]
+include = ["src/**/*", "tests/**/*", "LICENSE", "README.md"]
 
 [lib]
 name = "strftime"

--- a/README.md
+++ b/README.md
@@ -66,3 +66,14 @@ releases.
 
 `strftime-ruby` is licensed under the [MIT License](LICENSE) (c) Ryan Lopopolo
 and x-hgg-x.
+
+This repository includes a vendored copy of [`strftime.c`] from Ruby 3.1.2,
+which is licensed under the [Ruby license] or [BSD 2-clause license]. See
+[`vendor/README.md`] for more details. These sources are not distributed on
+[crates.io].
+
+[`strftime.c`]: vendor/ruby-3.1.2/strftime.c
+[ruby license]: vendor/ruby-3.1.2/COPYING
+[bsd 2-clause license]: vendor/ruby-3.1.2/BSDL
+[`vendor/readme.md`]: vendor/README.md
+[crates.io]: https://crates.io/

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -7,7 +7,10 @@
 The `strftime.c` source is vendored here as the reference implementation whose
 behavior this crate seeks to match.
 
-This source is based on [MRI Ruby 3.1.2][mri-3.1.2-strftime].
+This source file is from [MRI Ruby 3.1.2][mri-3.1.2-strftime], which is licensed
+under the [Ruby license] or [BSD 2-clause license].
 
 [ruby]: https://github.com/ruby/ruby
 [mri-3.1.2-strftime]: https://github.com/ruby/ruby/blob/v3_1_2/strftime.c
+[ruby license]: ruby-3.1.2/COPYING
+[bsd 2-clause license]: ruby-3.1.2/BSDL

--- a/vendor/ruby-3.1.2/BSDL
+++ b/vendor/ruby-3.1.2/BSDL
@@ -1,0 +1,22 @@
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.


### PR DESCRIPTION
Do not distribute vendored code on crates.io.