### PR TITLE
Prepare for v1.0.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "strftime-ruby"
 # remember to set `html_root_url` in `src/lib.rs`.
-version = "0.1.0"
+version = "1.0.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>", "x-hgg-x"]
 license = "MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-strftime-ruby = "0.1.0"
+strftime-ruby = "1.0.0"
 ```
 
 ## Crate features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@
 //! days in that year. The days before the first week are in the last week of
 //! the previous year.
 
-#![doc(html_root_url = "https://docs.rs/strftime-ruby/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/strftime-ruby/1.0.0")]
 #![no_std]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
# Release Notes

Release 1.0.0 of strftime-ruby.

[`strftime-ruby` is available on crates.io](https://crates.io/crates/strftime-ruby/1.0.0).

`strftime-ruby` is a Ruby 3.1.2 compatible implementation of the [`Time#strftime`] method. The `strftime` routines provided by this crate are [POSIX-compatible], except for intentionally ignoring the `E` and `O` modified conversion specifiers.

[`Time#strftime`]: https://ruby-doc.org/core-3.1.2/Time.html#method-i-strftime
[POSIX-compatible]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/strftime.html

## API

There are 5 `strftime` functions in this crate which vary in the type of format specifier they take and how they write the formatted output:

- `strftime::buffered::strftime`: Takes a `&[u8]` format specifier and writes to the provided byte slice.
- `strftime::fmt::strftime`: Takes a `&str` format specifier and writes to the provided `core::fmt::Write` object.
- `strftime::bytes::strftime`: Takes a `&[u8]` format specifier and writes to a newly allocated `Vec`, which is returned.
- `strftime::string::strftime`: Takes a `&str` format specifier and writes to a newly allocated `String`, which is returned.
- `strftime::io::strftime`: Takes a `&[u8]` format specifier and writes to the provided `std::io::Write` object.

## Allocations

The only routines that allocate in this crate are `strftime::bytes::strftime` and `strftime::string::strftime`. These routines use fallible allocation APIs from `alloc` and return errors to callers.

`strftime::fmt::strftime` and `strftime::io::strftime` perform no allocations on their own, but the provided writers may allocate.

## Cargo Features

`strftime-ruby` has **alloc** and **std** features. All features are enabled by default.

`strftime::buffered::strftime` and `strftime::fmt::strftime` are available when this crate is compiled without any features and are usable in a `no_std` context.

The **alloc** feature enables `strftime::bytes::strftime` and `strftime::string::strftime`.

The **std** feature enables `strftime::io::strftime`.

## Test Coverage

`strftime-ruby` has 100% line coverage, which is enforced by CI, and is fuzzed regularly.