### PR TITLE
Fix link check exclude to allow README in top of vendor directory

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -95,7 +95,7 @@ namespace :release do
   link_check_files = FileList.new('**/*.md') do |f|
     f.exclude('node_modules/**/*')
     f.exclude('**/target/**/*')
-    f.exclude('**/vendor/**/*')
+    f.exclude('**/vendor/*/**/*')
     f.include('*.md')
     f.include('**/vendor/*.md')
   end


### PR DESCRIPTION
Markdown has no broken links apart from the `docs.rs` link which will get fixed when we publish:

```console
$ rake release:markdown_link_check
npx markdown-link-check --config .github/markdown-link-check.json README.md

FILE: README.md
  [✓] https://github.com/artichoke/strftime-ruby/actions
  [✓] https://codecov.artichokeruby.org/strftime-ruby/index.html
  [✓] https://discord.gg/QCe2tp2
  [✓] https://twitter.com/artichokeruby
  [✓] https://crates.io/crates/strftime-ruby
  [✓] https://artichoke.github.io/strftime-ruby/strftime/
  [✓] https://ruby-doc.org/core-3.1.2/Time.html#method-i-strftime
  [✓] https://github.com/artichoke/artichoke
  [✓] https://doc.rust-lang.org/std/error/trait.Error.html
  [✓] https://doc.rust-lang.org/alloc/
  [✓] https://doc.rust-lang.org/alloc/vec/struct.Vec.html
  [✓] https://doc.rust-lang.org/alloc/string/struct.String.html
  [✓] https://doc.rust-lang.org/alloc/vec/struct.Vec.html#method.try_reserve
  [✓] LICENSE
  [✓] vendor/ruby-3.1.2/strftime.c
  [✓] vendor/ruby-3.1.2/COPYING
  [✓] vendor/ruby-3.1.2/BSDL
  [✓] vendor/README.md
  [✓] https://crates.io/
  [✓] https://github.com/artichoke/strftime-ruby/workflows/CI/badge.svg
  [✓] https://codecov.artichokeruby.org/strftime-ruby/badges/flat.svg?nocache=2
  [/] https://img.shields.io/discord/607683947496734760
  [/] https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social
  [/] https://img.shields.io/crates/v/strftime-ruby.svg
  [/] https://img.shields.io/badge/docs-trunk-blue.svg

  25 links checked.
npx markdown-link-check --config .github/markdown-link-check.json vendor/README.md

FILE: vendor/README.md
  [✓] https://github.com/ruby/ruby
  [✓] https://github.com/ruby/ruby/blob/v3_1_2/strftime.c
  [✓] ruby-3.1.2/COPYING
  [✓] ruby-3.1.2/BSDL

  4 links checked.
```