### PR TITLE
Add new words to spellcheck dictionary

### DIFF
--- a/.config/artichoke.dic
+++ b/.config/artichoke.dic
@@ -10,10 +10,12 @@ VMS
 alloc
 callouts
 formatter
+io
 std
 struct/MS
 subslice
 tokio
 tuple
 unterminated
+vendored
 x-hgg-x


### PR DESCRIPTION
Fixes these issues flagged by `cargo-spellcheck`:

```console
$ cargo spellcheck
error: spellcheck(Hunspell)
   --> /Users/lopopolo/dev/artichoke/strftime-ruby/README.md:70
    |
 70 | This repository includes a vendored copy of [`strftime.c`] from Ruby 3.1.2,
    |                            ^^^^^^^^
    | - vendor ed, vendor-ed, vendor, endorsed, endeavored, or vended
    |
    |   Possible spelling mistake found.

error: spellcheck(Hunspell)
   --> /Users/lopopolo/dev/artichoke/strftime-ruby/README.md:73
    |
 73 | [crates.io].
    |         ^^
    | - oi, Io, ii, ion, bio, Rio, is, or one of 7 others
    |
    |   Possible spelling mistake found.
```