### PR TITLE
Add tests for check format assertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,7 @@ tags
 
 # Coverage files
 *.profraw
+
+# cargo mutants
+mutants.out/
+mutants.out.old/

--- a/src/tests/format.rs
+++ b/src/tests/format.rs
@@ -48,7 +48,7 @@ fn test_check_all_panics_on_error() {
         MockTime { year: 1111,  ..Default::default() },
     ];
 
-    check_all(&times, "'%Y'",    &["'-1111'", "'-0011'", "'0001'",  "'1112'"]);
+    check_all(&times, "'%Y'", &["'-1111'", "'-0011'", "'0001'",  "'1112'"]);
 }
 
 #[test]

--- a/src/tests/format.rs
+++ b/src/tests/format.rs
@@ -29,6 +29,29 @@ fn check_all(times: &[MockTime<'_>], format: &str, all_expected: &[&str]) {
 }
 
 #[test]
+#[should_panic]
+#[rustfmt::skip]
+fn test_check_format_panics_on_error() {
+    let time = MockTime { year: 1111,  ..Default::default() };
+
+    check_format(&time, "'%Y'", "'1112'");
+}
+
+#[test]
+#[should_panic]
+#[rustfmt::skip]
+fn test_check_all_panics_on_error() {
+    let times = [
+        MockTime { year: -1111, ..Default::default() },
+        MockTime { year: -11,   ..Default::default() },
+        MockTime { year: 1,     ..Default::default() },
+        MockTime { year: 1111,  ..Default::default() },
+    ];
+
+    check_all(&times, "'%Y'",    &["'-1111'", "'-0011'", "'0001'",  "'1112'"]);
+}
+
+#[test]
 #[rustfmt::skip]
 fn test_format_year_4_digits() {
     let times = [


### PR DESCRIPTION
`cargo mutants` is a tool that replaces functions in a codebase with
stub implementations like `Ok(Default::default())` to check and see if
any tests catch the "incorrect" implementation.

`cargo mutants` found that `check_all` and `check_format` assertion
helpers in `crate::tests::format` were not covered by tests.

Add two tests annotated with `#[should_panic]` that ensure these
assertion helpers fail a test when given a mismatched format string and
result.

Before:

```console
$ cargo mutants
Freshen source tree ... ok in 7.507s
Copy source and build products to scratch directory ... 639 MB in 0.925s
Unmutated baseline ... ok in 2.319s
Auto-set test timeout to 20.0s
Found 71 mutants to test
src/tests/format.rs:24: replace check_all with () ... NOT CAUGHT in 2.818s
src/tests/format.rs:12: replace check_format with () ... NOT CAUGHT in 2.636s
71 mutants tested in 2:05: 2 missed, 61 caught, 8 unviable
```

After:

```console
$ cargo mutants
Freshen source tree ... ok in 0.679s
Copy source and build products to scratch directory ... 639 MB in 0.747s
Unmutated baseline ... ok in 2.258s
Auto-set test timeout to 20.0s
Found 71 mutants to test
71 mutants tested in 1:56: 63 caught, 8 unviable
```