### PR TITLE
Add missing Ruby lint and format job in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,6 +121,22 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --all-targets
 
+  ruby:
+    name: Lint and format Ruby
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Ruby toolchain
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ".ruby-version"
+          bundler-cache: true
+
+      - name: Lint and check formatting with Rubocop
+        run: bundle exec rubocop --format github
+
   text:
     name: Lint and format text
     runs-on: ubuntu-latest


### PR DESCRIPTION
This check is a standard check across all artichoke repositories, but was missing here and a few other places.