### PR TITLE
Fix `clippy::single_match_else` warning on new stable 1.64.0

### DIFF
--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -764,14 +764,13 @@ impl<'t, 'f, T: CheckedTime> TimeFormatter<'t, 'f, T> {
                 break;
             }
 
-            match Self::parse_spec(&mut cursor)? {
-                Some(piece) => piece.fmt(&mut f, self.time)?,
-                None => {
-                    // No valid format specifier was found
-                    let remaining_after = cursor.remaining();
-                    let text = &remaining_before[..remaining_before.len() - remaining_after.len()];
-                    f.write_all(text)?;
-                }
+            if let Some(piece) = Self::parse_spec(&mut cursor)? {
+                piece.fmt(&mut f, self.time)?;
+            } else {
+                // No valid format specifier was found
+                let remaining_after = cursor.remaining();
+                let text = &remaining_before[..remaining_before.len() - remaining_after.len()];
+                f.write_all(text)?;
             }
         }
 


### PR DESCRIPTION
The weekly CI job just failed on trunk.

```console
$ cargo clippy --workspace
    Checking strftime-ruby v1.0.0 (/Users/lopopolo/dev/artichoke/strftime-ruby)
warning: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
   --> src/format/mod.rs:767:13
    |
767 | /             match Self::parse_spec(&mut cursor)? {
768 | |                 Some(piece) => piece.fmt(&mut f, self.time)?,
769 | |                 None => {
770 | |                     // No valid format specifier was found
...   |
774 | |                 }
775 | |             }
    | |_____________^
    |
note: the lint level is defined here
   --> src/lib.rs:3:9
    |
3   | #![warn(clippy::pedantic)]
    |         ^^^^^^^^^^^^^^^^
    = note: `#[warn(clippy::single_match_else)]` implied by `#[warn(clippy::pedantic)]`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_match_else
help: try this
    |
767 ~             if let Some(piece) = Self::parse_spec(&mut cursor)? { piece.fmt(&mut f, self.time)? } else {
768 +                 // No valid format specifier was found
769 +                 let remaining_after = cursor.remaining();
770 +                 let text = &remaining_before[..remaining_before.len() - remaining_after.len()];
771 +                 f.write_all(text)?;
772 +             }
    |

warning: `strftime-ruby` (lib) generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 1.77s
```