### PR TITLE
Add tests for boundary conditions when computing ISO week number

### DIFF
--- a/src/tests/format.rs
+++ b/src/tests/format.rs
@@ -922,3 +922,34 @@ fn test_format_copies_non_specifier_bytes() {
         ],
     );
 }
+
+#[test]
+fn test_chrono_pr_966_week_numbers() {
+    let times = [
+        MockTime::new(2020, 1, 12, 0, 0, 0, 0, 0, 12, 0, false, 0, ""),
+        MockTime::new(2019, 1, 13, 0, 0, 0, 0, 0, 13, 0, false, 0, ""),
+        MockTime::new(2007, 12, 31, 0, 0, 0, 0, 1, 365, 0, false, 0, ""),
+    ];
+
+    check_all(
+        &times,
+        "%Y-%W-%w",
+        &[
+            // ```
+            // [3.1.2] > Time.utc(2020, 1, 12).strftime("%Y-%W-%w")
+            // => "2020-01-0"
+            // ```
+            "2020-01-0",
+            // ```
+            // [3.1.2] > Time.utc(2019, 1, 13).strftime("%Y-%W-%w")
+            // => "2019-01-0"
+            // ```
+            "2019-01-0",
+            // ```
+            // [3.1.2] > Time.utc(2007, 12, 31).strftime("%Y-%W-%w")
+            // => "2007-53-1"
+            // ```
+            "2007-53-1",
+        ],
+    );
+}


### PR DESCRIPTION
These tests were pulled from the following PR in chrono:

- https://github.com/chronotope/chrono/pull/966

Add a single test with these boundary condition dates. The dates were validated with MRI Ruby v3.1.2. The third test case differs between chrono and MRI, but since we target MRI, use it as the source of truth.

No logic was changed as part of this commit, only additional tests were added.