### PR TITLE
Remove dependency on actions-rs organization GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,10 +33,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/build-and-test@v1
         with:
           toolchain: stable
-          profile: minimal
 
       - name: Compile
         run: cargo build --verbose
@@ -72,11 +71,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/build-and-test@v1
         with:
           toolchain: "1.58.0"
-          profile: minimal
-          override: true
 
       - name: Compile
         run: cargo build --verbose
@@ -105,21 +102,15 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/lint-and-format@v1
         with:
           toolchain: stable
-          override: true
-          profile: minimal
-          components: rustfmt, clippy
 
       - name: Check formatting
-        run: cargo fmt -- --check --color=auto
+        run: cargo fmt --check
 
       - name: Lint with Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets
+        run: cargo clippy --workspace --all-features --all-targets
 
   ruby:
     name: Lint and format Ruby

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -16,11 +16,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/build-and-test@v1
         with:
           toolchain: nightly
-          profile: minimal
-          override: true
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
@@ -40,11 +38,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/build-and-test@v1
         with:
           toolchain: nightly
-          profile: minimal
-          override: true
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz


### PR DESCRIPTION
These actions are unmaintained and use deprecated GitHub Actions technologies.

See: https://github.com/artichoke/project-infrastructure/issues/265