### PR TITLE
Suppress `clippy::should_panic_without_expect` lint violations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw-ucrt
 
 DEPENDENCIES
   bundler-audit (~> 0.9)

--- a/src/format/assert.rs
+++ b/src/format/assert.rs
@@ -50,6 +50,7 @@ pub(crate) const fn assert_to_ascii_uppercase(table: &[&str], upper_table: &[&st
 }
 
 #[cfg(test)]
+#[allow(clippy::should_panic_without_expect)]
 mod tests {
     use super::*;
 

--- a/src/tests/format.rs
+++ b/src/tests/format.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::should_panic_without_expect)]
+
 use crate::format::TimeFormatter;
 use crate::{Error, Time};
 


### PR DESCRIPTION
This lint fires on generic assert helpers for test and const programming,
where the error messages are not user-facing.