### PR TITLE
Be more strict about which files are included in crate packaging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ homepage = "https://github.com/artichoke/strftime-ruby"
 description = "Ruby `Time#strftime` parser and formatter"
 keywords = ["ruby", "strftime", "time"]
 categories = ["date-and-time", "no-std", "no-std::no-alloc", "parser-implementations", "value-formatting"]
-include = ["src/**/*", "tests/**/*", "LICENSE", "README.md"]
+include = ["/src/**/*", "/tests/**/*", "/LICENSE", "/README.md"]
 
 [lib]
 name = "strftime"


### PR DESCRIPTION
Without these changes, `prettier` metadata in `node_modules` is included:

```console
$ cargo package --list --allow-dirty
.cargo_vcs_info.json
Cargo.toml
Cargo.toml.orig
LICENSE
README.md
node_modules/prettier/LICENSE
node_modules/prettier/README.md
src/format/assert.rs
src/format/check.rs
src/format/mod.rs
src/format/utils.rs
src/format/week.rs
src/format/write.rs
src/lib.rs
src/mock.rs.in
src/tests/error.rs
src/tests/format.rs
src/tests/mod.rs
tests/version_numbers.rs
vendor/README.md
```