### PR TITLE
chore: Update `.github/workflows/code-coverage.yaml` in `artichoke/st…

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Install nightly Rust toolchain
         uses: artichoke/setup-rust/code-coverage@v1.12.1
@@ -61,7 +63,7 @@ jobs:
         run: grcov strftime-ruby*.profraw --source-dir . --keep-only 'src/**/*.rs' --binary-path target/debug -t covdir --filter covered -o target/coverage/coverage.json
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        uses: aws-actions/configure-aws-credentials@4fc4975a852c8cd99761e2de1f4ba73402e44dd9 # v4.0.3
         if: github.ref == 'refs/heads/trunk'
         with:
           aws-region: us-west-2
@@ -82,8 +84,13 @@ jobs:
 
       - name: Check missed lines
         shell: python
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_NUMBER: ${{ github.event.number }}
         run: |
           import json
+          import os
           from urllib.request import urlopen
 
           trunk_coverage_url = "https://codecov.artichokeruby.org/strftime-ruby/coverage.json"
@@ -101,7 +108,7 @@ jobs:
               print("")
 
 
-          if "${{ github.ref_name }}" == "trunk":
+          if os.environ.get("GITHUB_REF_NAME") == "trunk":
               # We don't need to compare trunk coverage to itself
               exit(0)
 
@@ -114,8 +121,8 @@ jobs:
               branch_coverage = json.load(local)
 
           on = None
-          if "${{ github.event_name }}" == "pull_request":
-              on = "PR artichoke/strftime-ruby#${{ github.event.number }}"
+          if os.environ.get("GITHUB_EVENT_NAME") == "pull_request":
+              on = "PR artichoke/strftime-ruby#" + os.environ.get("GITHUB_EVENT_NUMBER")
 
           print_report(branch_coverage, on=on)
 


### PR DESCRIPTION
…rftime-ruby`

Managed by Terraform.

See [zizmor's template-injection lint](https://woodruffw.github.io/zizmor/audits/#template-injection).

## Contents

```
---
name: Code Coverage
"on":
  push:
    branches:
      - trunk
  pull_request:
    branches:
      - trunk
jobs:
  generate:
    name: Generate
    permissions:
      id-token: write
      contents: read
    runs-on: ubuntu-latest
    env:
      RUST_BACKTRACE: 1
      CARGO_NET_GIT_FETCH_WITH_CLI: true
      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
    steps:
      - name: Checkout repository
        uses: actions/checkout@v4.2.2
        with:
          persist-credentials: false

      - name: Install nightly Rust toolchain
        uses: artichoke/setup-rust/code-coverage@v1.12.1

      - name: Setup grcov
        run: |
          release_url="$(curl \
            --url https://api.github.com/repos/mozilla/grcov/releases \
            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
            --header 'content-type: application/json' \
            --silent \
            --fail \
            --retry 5 \
            | jq -r '.[0].assets
                     | map(select(.browser_download_url | test(".*x86_64-unknown-linux-musl.tar.bz2$")))
                     | .[0].browser_download_url'
          )"
          curl -sL "$release_url" | sudo tar xvj -C /usr/local/bin/

      - name: Show grcov version
        run: grcov --version

      - name: Generate coverage
        env:
          LLVM_PROFILE_FILE: "strftime-ruby-%m-%p.profraw"
          RUSTFLAGS: "-C instrument-coverage"
          # Unstable feature: `--persist-doctests`: persist doctest executables after running
          # https://rustwiki.org/en/rustdoc/unstable-features.html#--persist-doctests-persist-doctest-executables-after-running
          #
          # Used to allow grcov to use these sources to generate coverage metrics.
          RUSTDOCFLAGS: "-C instrument-coverage -Z unstable-options --persist-doctests target/debug/doctests"
        run: cargo test

      - name: Generate HTML report
        run: grcov strftime-ruby*.profraw --source-dir . --keep-only 'src/**/*.rs' --binary-path target/debug -t html --filter covered -o target/coverage

      - name: Generate detailed JSON report
        run: grcov strftime-ruby*.profraw --source-dir . --keep-only 'src/**/*.rs' --binary-path target/debug -t covdir --filter covered -o target/coverage/coverage.json

      - name: Configure AWS Credentials
        uses: aws-actions/configure-aws-credentials@4fc4975a852c8cd99761e2de1f4ba73402e44dd9 # v4.0.3
        if: github.ref == 'refs/heads/trunk'
        with:
          aws-region: us-west-2
          role-to-assume: arn:aws:iam::447522982029:role/gha-strftime-ruby-s3-backup-20220817011212567800000002
          role-session-name: GitHubActionsRustCodeCoverage@strftime-ruby

      - name: Show AWS caller identity
        if: github.ref == 'refs/heads/trunk'
        run: aws sts get-caller-identity

      - name: Upload archives to S3
        if: github.ref == 'refs/heads/trunk'
        run: |
          aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --delete --sse AES256 --exclude '*' --include '*.svg' --content-type 'image/svg+xml'
          aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --delete --sse AES256 --exclude '*' --include '*.html' --content-type 'text/html'
          aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --delete --sse AES256 --exclude '*' --include '*.json' --content-type 'application/json'
          aws s3 sync target/coverage/ s3://artichoke-forge-code-coverage-us-west-2/strftime-ruby/ --delete --sse AES256 --include '*' --exclude '*.svg' --exclude '*.html' --exclude '*.json'

      - name: Check missed lines
        shell: python
        env:
          GITHUB_REF_NAME: ${{ github.ref_name }}
          GITHUB_EVENT_NAME: ${{ github.event_name }}
          GITHUB_EVENT_NUMBER: ${{ github.event.number }}
        run: |
          import json
          import os
          from urllib.request import urlopen

          trunk_coverage_url = "https://codecov.artichokeruby.org/strftime-ruby/coverage.json"


          def print_report(coverage, *, on=None):
              if on is None:
                  raise ValueError("must provide `on` kwarg")

              print(f"On {on}:")
              print("coveragePercent =", coverage["coveragePercent"])
              print("linesCovered =", coverage["linesCovered"])
              print("linesMissed =", coverage["linesMissed"])
              print("linesTotal =", coverage["linesTotal"])
              print("")


          if os.environ.get("GITHUB_REF_NAME") == "trunk":
              # We don't need to compare trunk coverage to itself
              exit(0)

          with urlopen(trunk_coverage_url, data=None, timeout=3) as remote:
              trunk_coverage = json.load(remote)

          print_report(trunk_coverage, on="branch trunk")

          with open("target/coverage/coverage.json") as local:
              branch_coverage = json.load(local)

          on = None
          if os.environ.get("GITHUB_EVENT_NAME") == "pull_request":
              on = "PR artichoke/strftime-ruby#" + os.environ.get("GITHUB_EVENT_NUMBER")

          print_report(branch_coverage, on=on)

          is_ok = branch_coverage["linesMissed"] <= trunk_coverage["linesMissed"]
          exit(0) if is_ok else exit(1)
```