### PR TITLE
Fixup rust-analyzer warnings

### DIFF
--- a/src/format/check.rs
+++ b/src/format/check.rs
@@ -116,8 +116,7 @@ impl<T: Time> CheckedTime for T {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    include!("../mock.rs.in");
+    use crate::tests::MockTime;
 
     fn check<T>(ok: bool, result: &Result<T, Error>) {
         if ok {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,7 +283,7 @@ pub mod buffered {
     ///
     /// // Not shown: create a time implementation with the year 1970
     /// // let time = ...;
-    /// # include!("mock.rs.in");
+    /// # include!("tests/mock.rs");
     /// # fn main() -> Result<(), strftime::Error> {
     /// # let time = MockTime { year: 1970, ..Default::default() };
     /// assert_eq!(time.year(), 1970);
@@ -340,7 +340,7 @@ pub mod fmt {
     ///
     /// // Not shown: create a time implementation with the year 1970
     /// // let time = ...;
-    /// # include!("mock.rs.in");
+    /// # include!("tests/mock.rs");
     /// # fn main() -> Result<(), strftime::Error> {
     /// # let time = MockTime { year: 1970, ..Default::default() };
     /// assert_eq!(time.year(), 1970);
@@ -392,7 +392,7 @@ pub mod bytes {
     ///
     /// // Not shown: create a time implementation with the year 1970
     /// // let time = ...;
-    /// # include!("mock.rs.in");
+    /// # include!("tests/mock.rs");
     /// # fn main() -> Result<(), strftime::Error> {
     /// # let time = MockTime { year: 1970, ..Default::default() };
     /// assert_eq!(time.year(), 1970);
@@ -445,7 +445,7 @@ pub mod string {
     ///
     /// // Not shown: create a time implementation with the year 1970
     /// // let time = ...;
-    /// # include!("mock.rs.in");
+    /// # include!("tests/mock.rs");
     /// # fn main() -> Result<(), strftime::Error> {
     /// # let time = MockTime { year: 1970, ..Default::default() };
     /// assert_eq!(time.year(), 1970);
@@ -495,7 +495,7 @@ pub mod io {
     ///
     /// // Not shown: create a time implementation with the year 1970
     /// // let time = ...;
-    /// # include!("mock.rs.in");
+    /// # include!("tests/mock.rs");
     /// # fn main() -> Result<(), strftime::Error> {
     /// # let time = MockTime { year: 1970, ..Default::default() };
     /// assert_eq!(time.year(), 1970);

--- a/src/tests/mock.rs
+++ b/src/tests/mock.rs
@@ -1,18 +1,18 @@
 macro_rules! create_mock_time {
     ($($field_name:ident: $field_type:ty),*,) => {
         #[derive(Default, Clone, Copy)]
-        struct MockTime<'a> {
-            $($field_name: $field_type),*,
+        pub struct MockTime<'a> {
+            $(pub $field_name: $field_type),*,
         }
 
         impl<'a> MockTime<'a> {
             #[allow(clippy::too_many_arguments)]
-            fn new($($field_name: $field_type),*) -> Self {
+            pub fn new($($field_name: $field_type),*) -> Self {
                 Self { $($field_name),* }
             }
         }
 
-        impl<'a> Time for MockTime<'a> {
+        impl<'a> crate::Time for MockTime<'a> {
             $(fn $field_name(&self) -> $field_type { self.$field_name })*
         }
     };

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,11 +1,11 @@
 mod error;
 mod format;
+mod mock;
 mod rust_fmt_argument_max_padding;
 
 use crate::format::TimeFormatter;
-use crate::{Error, Time};
-
-include!("../mock.rs.in");
+use crate::Error;
+pub(crate) use mock::MockTime;
 
 fn get_format_err(time: &MockTime<'_>, format: &str) -> Error {
     TimeFormatter::new(time, format)


### PR DESCRIPTION
rust-analyzer has a known limitation where it will only load Rust files (those ending in a `.rs` extension) when parsing `include!` macros:

- https://github.com/rust-lang/rust-analyzer/issues/17828#issuecomment-2275386671

Move mock time into `tests/mock.rs` and make some tweaks to the source so it compiles in both integration tests, unit tests, and doctests.

This has the added benefit of letting VSCode apply syntax highlighting to the macros.