### PR TITLE
Handle large formatting widths by padding directly

### DIFF
--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -303,10 +303,10 @@ impl Piece {
         if self.flags.contains(Flag::LeftPadding) {
             write!(f, "{value}")
         } else if self.padding == Padding::Spaces {
-            let width = self.width.unwrap_or(default_width);
+            let width = self.pad_width(f, b' ', default_width)?;
             write!(f, "{value: >width$}")
         } else {
-            let width = self.width.unwrap_or(default_width);
+            let width = self.pad_width(f, b'0', default_width)?;
             write!(f, "{value:0width$}")
         }
     }
@@ -321,16 +321,24 @@ impl Piece {
         if self.flags.contains(Flag::LeftPadding) {
             write!(f, "{value}")
         } else if self.padding == Padding::Zeros {
-            let width = self.width.unwrap_or(default_width);
+            let width = self.pad_width(f, b'0', default_width)?;
             write!(f, "{value:0width$}")
         } else {
-            let width = self.width.unwrap_or(default_width);
+            let width = self.pad_width(f, b' ', default_width)?;
             write!(f, "{value: >width$}")
         }
     }
 
+    /// Returns the width to use for the padding.
+    ///
+    /// Prints any excessive padding directly.
+    fn pad_width(&self, f: &mut SizeLimiter<'_>, pad: u8, default: usize) -> Result<usize, Error> {
+        let width = self.width.unwrap_or(default);
+        f.pad(pad, width.saturating_sub(u16::MAX.into()))?;
+        Ok(width.min(u16::MAX.into()))
+    }
+
     /// Format nanoseconds with the specified precision.
-    #[allow(clippy::uninlined_format_args)] // for readability and symmetry between if branches
     fn format_nanoseconds(
         &self,
         f: &mut SizeLimiter<'_>,
@@ -341,38 +349,37 @@ impl Piece {
 
         if width <= 9 {
             let value = nanoseconds / 10u32.pow(9 - width as u32);
-            write!(f, "{value:0n$}", n = width)
+            write!(f, "{value:0width$}")
         } else {
-            write!(f, "{nanoseconds:09}{:0n$}", 0, n = width - 9)
+            write!(f, "{nanoseconds:09}")?;
+            f.pad(b'0', width - 9)
         }
     }
 
     /// Format a string value.
     fn format_string(&self, f: &mut SizeLimiter<'_>, s: &str) -> Result<(), Error> {
-        match self.width {
-            None => write!(f, "{s}"),
-            Some(width) => {
-                if self.flags.contains(Flag::LeftPadding) {
-                    write!(f, "{s}")
-                } else if self.padding == Padding::Zeros {
-                    write!(f, "{s:0>width$}")
-                } else {
-                    write!(f, "{s: >width$}")
-                }
-            }
+        if !self.flags.contains(Flag::LeftPadding) {
+            self.write_padding(f, s.len())?;
         }
+
+        write!(f, "{s}")
     }
 
     /// Write padding separately.
     fn write_padding(&self, f: &mut SizeLimiter<'_>, min_width: usize) -> Result<(), Error> {
-        if let Some(width) = self.width {
-            let n = width.saturating_sub(min_width);
+        let Some(width) = self.width else {
+            return Ok(());
+        };
 
-            match self.padding {
-                Padding::Zeros => write!(f, "{:0>n$}", "")?,
-                _ => write!(f, "{: >n$}", "")?,
-            };
-        }
+        let n = width.saturating_sub(min_width);
+
+        let pad = match self.padding {
+            Padding::Zeros => b'0',
+            _ => b' ',
+        };
+
+        f.pad(pad, n)?;
+
         Ok(())
     }
 
@@ -396,14 +403,34 @@ impl Piece {
         UtcOffset::new(hour, minute, second)
     }
 
-    /// Compute hour padding for the `%z` specifier.
-    fn hour_padding(&self, min_width: usize) -> usize {
-        const MIN_PADDING: usize = "+hh".len();
-
-        match self.width {
-            Some(width) => width.saturating_sub(min_width) + MIN_PADDING,
-            None => MIN_PADDING,
+    /// Write the hour sign.
+    fn write_hour_sign(f: &mut SizeLimiter<'_>, hour: f64) -> Result<(), Error> {
+        if hour.is_sign_negative() {
+            write!(f, "-")?;
+        } else {
+            write!(f, "+")?;
         }
+
+        Ok(())
+    }
+
+    /// Write the hour with padding for the `%z` specifier.
+    fn write_offset_hour(&self, f: &mut SizeLimiter<'_>, hour: f64, w: usize) -> Result<(), Error> {
+        let mut pad = self.width.unwrap_or(0).saturating_sub(w);
+
+        if hour < 10.0 {
+            pad += 1;
+        }
+
+        if self.padding == Padding::Spaces {
+            f.pad(b' ', pad)?;
+            Self::write_hour_sign(f, hour)?;
+        } else {
+            Self::write_hour_sign(f, hour)?;
+            f.pad(b'0', pad)?;
+        }
+
+        write!(f, "{:.0}", hour.abs())
     }
 
     /// Write the time zone UTC offset as `"+hh"`.
@@ -412,13 +439,7 @@ impl Piece {
         f: &mut SizeLimiter<'_>,
         utc_offset: &UtcOffset,
     ) -> Result<(), Error> {
-        let hour = utc_offset.hour;
-        let n = self.hour_padding("+hh".len());
-
-        match self.padding {
-            Padding::Spaces => write!(f, "{hour: >+n$.0}"),
-            _ => write!(f, "{hour:+0n$.0}"),
-        }
+        self.write_offset_hour(f, utc_offset.hour, "+hh".len())
     }
 
     /// Write the time zone UTC offset as `"+hhmm"`.
@@ -427,13 +448,10 @@ impl Piece {
         f: &mut SizeLimiter<'_>,
         utc_offset: &UtcOffset,
     ) -> Result<(), Error> {
-        let UtcOffset { hour, minute, .. } = utc_offset;
-        let n = self.hour_padding("+hhmm".len());
+        let UtcOffset { hour, minute, .. } = *utc_offset;
 
-        match self.padding {
-            Padding::Spaces => write!(f, "{hour: >+n$.0}{minute:02}"),
-            _ => write!(f, "{hour:+0n$.0}{minute:02}"),
-        }
+        self.write_offset_hour(f, hour, "+hhmm".len())?;
+        write!(f, "{minute:02}")
     }
 
     /// Write the time zone UTC offset as `"+hh:mm"`.
@@ -442,13 +460,10 @@ impl Piece {
         f: &mut SizeLimiter<'_>,
         utc_offset: &UtcOffset,
     ) -> Result<(), Error> {
-        let UtcOffset { hour, minute, .. } = utc_offset;
-        let n = self.hour_padding("+hh:mm".len());
+        let UtcOffset { hour, minute, .. } = *utc_offset;
 
-        match self.padding {
-            Padding::Spaces => write!(f, "{hour: >+n$.0}:{minute:02}"),
-            _ => write!(f, "{hour:+0n$.0}:{minute:02}"),
-        }
+        self.write_offset_hour(f, hour, "+hh:mm".len())?;
+        write!(f, ":{minute:02}")
     }
 
     /// Write the time zone UTC offset as `"+hh:mm:ss"`.
@@ -461,14 +476,10 @@ impl Piece {
             hour,
             minute,
             second,
-        } = utc_offset;
+        } = *utc_offset;
 
-        let n = self.hour_padding("+hh:mm:ss".len());
-
-        match self.padding {
-            Padding::Spaces => write!(f, "{hour: >+n$.0}:{minute:02}:{second:02}"),
-            _ => write!(f, "{hour:+0n$.0}:{minute:02}:{second:02}"),
-        }
+        self.write_offset_hour(f, hour, "+hh:mm:ss".len())?;
+        write!(f, ":{minute:02}:{second:02}")
     }
 
     /// Format time using the formatting directive.

--- a/src/format/utils.rs
+++ b/src/format/utils.rs
@@ -81,11 +81,31 @@ impl<'a> SizeLimiter<'a> {
             count: 0,
         }
     }
+
+    /// Pad with the specified character.
+    pub(crate) fn pad(&mut self, c: u8, n: usize) -> Result<(), Error> {
+        if self.count.saturating_add(n) > self.size_limit {
+            return Err(Error::FormattedStringTooLarge);
+        }
+
+        let buffer = [c; 1024];
+        let mut remaining = n;
+
+        while remaining > 0 {
+            let size = remaining.min(1024);
+            self.inner.write_all(&buffer[..size])?;
+            remaining -= size;
+        }
+
+        self.count += n;
+
+        Ok(())
+    }
 }
 
 impl Write for SizeLimiter<'_> {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
-        if self.count + buf.len() > self.size_limit {
+        if self.count.saturating_add(buf.len()) > self.size_limit {
             return Err(Error::FormattedStringTooLarge);
         }
 

--- a/src/tests/format.rs
+++ b/src/tests/format.rs
@@ -825,7 +825,7 @@ fn test_format_large_width() {
     check_format(&time, "%-100000000m", "1");
     check_format(&time, "%2147483648m", "%2147483648m");
 
-    let err = get_format_err(&time, "%2147483647m");
+    let err = get_format_err(&time, "%1000m");
     assert!(matches!(err, Error::WriteZero));
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -13,12 +13,6 @@ fn get_format_err(time: &MockTime<'_>, format: &str) -> Error {
         .unwrap_err()
 }
 
-fn get_format_err_bytes(time: &MockTime<'_>, format: &[u8]) -> Error {
-    TimeFormatter::new(time, format)
-        .fmt(&mut &mut [0u8; 100][..])
-        .unwrap_err()
-}
-
 fn check_format(time: &MockTime<'_>, format: &str, expected: &str) {
     const SIZE: usize = 100;
     let mut buf = [0u8; SIZE];

--- a/src/tests/rust_fmt_argument_max_padding.rs
+++ b/src/tests/rust_fmt_argument_max_padding.rs
@@ -26,7 +26,7 @@ use {
 
 use crate::Error;
 
-use super::{check_all, get_format_err, get_format_err_bytes, MockTime};
+use super::{check_all, MockTime};
 
 #[test]
 fn test_larger_than_int_max_formats_are_returned_verbatim() {
@@ -151,7 +151,7 @@ fn test_format_specifiers_int_max_fail() {
             .fmt(&mut &mut buf[..])
             .unwrap_err();
         assert!(
-            matches!(err, Error::WriteZero),
+            matches!(err, Error::FormattedStringTooLarge),
             "Expected write failure for specifier '{spec}' with width {width} but got unexpected error: {err:?}",
         );
     }


### PR DESCRIPTION
Fix the panics when using padding widths greater than `u16::MAX`.

Based on https://github.com/m-ou-se/strftime-ruby/commit/23c2037ab9847ab12d6de72d79bdf17e2feded3d.