### PR TITLE
Add memory bounds to fuzz harnesses, add test for a new crasher

### DIFF
--- a/fuzz/fuzz_targets/bytes.rs
+++ b/fuzz/fuzz_targets/bytes.rs
@@ -1,9 +1,8 @@
 #![no_main]
 
-use libfuzzer_sys::fuzz_target;
-
 mod mock;
 
+use libfuzzer_sys::fuzz_target;
 use mock::MockTime;
 
 fuzz_target!(|data: (MockTime, &[u8])| {

--- a/fuzz/fuzz_targets/bytes.rs
+++ b/fuzz/fuzz_targets/bytes.rs
@@ -1,11 +1,15 @@
 #![no_main]
 
+use libfuzzer_sys::fuzz_target;
+
 mod mock;
 
-use libfuzzer_sys::fuzz_target;
 use mock::MockTime;
 
 fuzz_target!(|data: (MockTime, &[u8])| {
     let (time, format) = data;
-    strftime::bytes::strftime(&time, format);
+    // Give each fuzzer input a 16kb buffer to write to.
+    let mut buf = vec![0u8; 16 * 1024].into_boxed_slice();
+    let _ignored = strftime::buffered::strftime(&time, format, &mut buf[..]);
+    let _ignored = strftime::io::strftime(&time, format, &mut &mut buf[..]);
 });

--- a/fuzz/fuzz_targets/mock.rs
+++ b/fuzz/fuzz_targets/mock.rs
@@ -8,13 +8,6 @@ macro_rules! create_mock_time {
             $($field_name: $field_type),*,
         }
 
-        impl<'a> MockTime<'a> {
-            #[allow(clippy::too_many_arguments)]
-            fn new($($field_name: $field_type),*) -> Self {
-                Self { $($field_name),* }
-            }
-        }
-
         impl<'a> Time for MockTime<'a> {
             $(fn $field_name(&self) -> $field_type { self.$field_name })*
         }

--- a/fuzz/fuzz_targets/string.rs
+++ b/fuzz/fuzz_targets/string.rs
@@ -1,11 +1,48 @@
 #![no_main]
 
-mod mock;
+use core::fmt;
 
 use libfuzzer_sys::fuzz_target;
+
+mod mock;
+
 use mock::MockTime;
+
+struct LimitedBuf<'a> {
+    buf: &'a mut [u8],
+    pos: usize,
+}
+
+impl<'a> fmt::Write for LimitedBuf<'a> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let bytes = s.as_bytes();
+        let remaining = self.buf.len().saturating_sub(self.pos);
+        let to_copy = remaining.min(bytes.len());
+
+        if to_copy == 0 {
+            return Err(fmt::Error);
+        }
+
+        self.buf[self.pos..self.pos + to_copy].copy_from_slice(&bytes[..to_copy]);
+        self.pos += to_copy;
+
+        if to_copy < bytes.len() {
+            Err(fmt::Error) // signal that buffer was too small
+        } else {
+            Ok(())
+        }
+    }
+}
 
 fuzz_target!(|data: (MockTime, &str)| {
     let (time, format) = data;
-    strftime::string::strftime(&time, format);
+    // Give each fuzzer input a 16kb buffer to write to.
+    let mut buf = vec![0u8; 16 * 1024].into_boxed_slice();
+
+    let mut writer = LimitedBuf {
+        buf: &mut buf[..],
+        pos: 0,
+    };
+
+    let _ignored = strftime::fmt::strftime(&time, format, &mut writer);
 });

--- a/fuzz/fuzz_targets/string.rs
+++ b/fuzz/fuzz_targets/string.rs
@@ -1,11 +1,9 @@
 #![no_main]
 
-use core::fmt;
-
-use libfuzzer_sys::fuzz_target;
-
 mod mock;
 
+use core::fmt;
+use libfuzzer_sys::fuzz_target;
 use mock::MockTime;
 
 struct LimitedBuf<'a> {
@@ -16,21 +14,17 @@ struct LimitedBuf<'a> {
 impl<'a> fmt::Write for LimitedBuf<'a> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         let bytes = s.as_bytes();
-        let remaining = self.buf.len().saturating_sub(self.pos);
-        let to_copy = remaining.min(bytes.len());
+        let remaining_buf = &mut self.buf[self.pos..];
 
-        if to_copy == 0 {
+        if remaining_buf.len() < bytes.len() {
+            // Signal that buffer was too small.
             return Err(fmt::Error);
         }
 
-        self.buf[self.pos..self.pos + to_copy].copy_from_slice(&bytes[..to_copy]);
-        self.pos += to_copy;
+        remaining_buf[..bytes.len()].copy_from_slice(bytes);
+        self.pos += bytes.len();
 
-        if to_copy < bytes.len() {
-            Err(fmt::Error) // signal that buffer was too small
-        } else {
-            Ok(())
-        }
+        Ok(())
     }
 }
 

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -846,6 +846,11 @@ impl<'t, 'f, T: CheckedTime> TimeFormatter<'t, 'f, T> {
                 Some(&b'#') => {
                     flags.set(Flag::ChangeCase);
                 }
+                Some(byte) if !byte.is_ascii() => {
+                    // We've found a multi-byte UTF-8 character sequence. All
+                    // specifiers must be ASCII-only, so this is invalid.
+                    return Ok(None);
+                }
                 _ => break,
             }
             cursor.next();

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -847,8 +847,8 @@ impl<'t, 'f, T: CheckedTime> TimeFormatter<'t, 'f, T> {
                     flags.set(Flag::ChangeCase);
                 }
                 Some(byte) if !byte.is_ascii() => {
-                    // We've found a multi-byte UTF-8 character sequence. All
-                    // specifiers must be ASCII-only, so this is invalid.
+                    // We've found a multi-byte UTF-8 character sequence.
+                    // All specifiers must be ASCII-only, so this is invalid.
                     return Ok(None);
                 }
                 _ => break,
@@ -935,15 +935,24 @@ impl<'t, 'f, T: CheckedTime> TimeFormatter<'t, 'f, T> {
                 (b'z', Spec::TimeZoneOffsetHourMinute),
             ]);
 
-            match cursor.next() {
-                Some(x) => match POSSIBLE_SPECS.binary_search_by_key(&x, |&(c, _)| c) {
-                    #[expect(
-                        clippy::indexing_slicing,
-                        reason = "index is returned from binary search"
-                    )]
-                    Ok(index) => Some(POSSIBLE_SPECS[index].1),
-                    Err(_) => None,
-                },
+            match cursor.remaining().first() {
+                Some(x) if !x.is_ascii() => {
+                    // We've found a multi-byte UTF-8 character sequence.
+                    // All specifiers must be ASCII-only, so this is invalid.
+                    return Ok(None);
+                }
+                Some(x) => {
+                    cursor.next();
+
+                    match POSSIBLE_SPECS.binary_search_by_key(&x, |(c, _)| c) {
+                        #[expect(
+                            clippy::indexing_slicing,
+                            reason = "index is returned from binary search"
+                        )]
+                        Ok(index) => Some(POSSIBLE_SPECS[index].1),
+                        Err(_) => None,
+                    }
+                }
                 None => return Err(Error::InvalidFormatString),
             }
         } else if cursor.read_optional_tag(b"z") {

--- a/src/tests/format.rs
+++ b/src/tests/format.rs
@@ -916,7 +916,13 @@ fn test_multibyte_utf8_characters_after_percent_treated_as_literal() {
 
     let time = MockTime::new(1970, 1, 1, 0, 0, 0, 0, 4, 1, 0, false, 0, "");
 
-    for format in ["\u{1e}%ˉ0", "%ݯ\u{2}", "%Ư"] {
+    for format in [
+        "\u{1e}%\u{02c9}0",
+        "%\u{076f}\u{2}",
+        "%\u{01af}",
+        "%10\u{94}\u{6}",
+        "%100000\u{94}\u{6}",
+    ] {
         let mut buf = String::new();
         crate::fmt::strftime(&time, format, &mut buf).unwrap();
         assert_eq!(buf, format);

--- a/src/tests/format.rs
+++ b/src/tests/format.rs
@@ -647,13 +647,15 @@ fn test_format_tabulation() {
 fn test_format_percent() {
     let times = [MockTime::default()];
 
-    check_all(&times, "'%%'",      &["'%'"]);
-    check_all(&times, "'%1%'",     &["'%'"]);
-    check_all(&times, "'%6%'",     &["'     %'"]);
-    check_all(&times, "'%-_#^6%'", &["'%'"]);
-    check_all(&times, "'%-0^6%'",  &["'%'"]);
-    check_all(&times, "'%0_#6%'",  &["'     %'"]);
-    check_all(&times, "'%_06%'",   &["'00000%'"]);
+    check_all(&times, "'%%'",       &["'%'"]);
+    check_all(&times, "'%%Q'",      &["'%Q'"]);
+    check_all(&times, "'%%%%%%%Q'", &["'%%%%Q'"]);
+    check_all(&times, "'%1%'",      &["'%'"]);
+    check_all(&times, "'%6%'",      &["'     %'"]);
+    check_all(&times, "'%-_#^6%'",  &["'%'"]);
+    check_all(&times, "'%-0^6%'",   &["'%'"]);
+    check_all(&times, "'%0_#6%'",   &["'     %'"]);
+    check_all(&times, "'%_06%'",    &["'00000%'"]);
 }
 
 #[test]
@@ -905,4 +907,18 @@ fn test_chrono_pr_966_week_numbers() {
             "2007-53-1",
         ],
     );
+}
+
+#[test]
+#[cfg(feature = "alloc")]
+fn test_multibyte_utf8_characters_after_percent_treated_as_literal() {
+    use alloc::string::String;
+
+    let time = MockTime::new(1970, 1, 1, 0, 0, 0, 0, 4, 1, 0, false, 0, "");
+
+    for format in ["\u{1e}%ˉ0", "%ݯ\u{2}", "%Ư"] {
+        let mut buf = String::new();
+        crate::fmt::strftime(&time, format, &mut buf).unwrap();
+        assert_eq!(buf, format);
+    }
 }


### PR DESCRIPTION
With the changes we've made recently, the fuzzer has been running out of memory by discovering very large padding :joy:

In this commit, I attempted to fix these fuzzing failures by using the `strftime::io` and `strftime::fmt` variants. In `strftime::fmt`, the fuzzer immediately found a crash.

If a multibyte UTF-8 sequence appears immediately following a `%` spec begin marker, the loop to pluck out padding consumes one element from the cursor and then breaks. This leads to pushing a partial UTF-8 character into the `fmt::Write` instance, which causes a panic in the underlying `String` because the string's contents is now malformed UTF-8.

Add a test and break with `None` if encountering a non-ASCII byte while processing the spec.

I've also cleaned up the fuzz targets so they build without warnings.