### PR TITLE
Prep for v1.3.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "strftime-ruby"
 # remember to set `html_root_url` in `src/lib.rs`.
-version = "1.3.0"
+version = "1.3.1"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>", "x-hgg-x"]
 license = "MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-strftime-ruby = "1.3.0"
+strftime-ruby = "1.3.1"
 ```
 
 ## Crate features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@
 //! days in that year. The days before the first week are in the last week of
 //! the previous year.
 
-#![doc(html_root_url = "https://docs.rs/strftime-ruby/1.3.0")]
+#![doc(html_root_url = "https://docs.rs/strftime-ruby/1.3.1")]
 #![no_std]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
Push out a release for the fuzzer-found crashes in spec parsing.