### PR TITLE
Improve fuzzing harness to avoid memory exhaustion

### DIFF
--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -24,7 +24,10 @@ jobs:
         run: cargo install cargo-fuzz
 
       - name: Fuzz
-        run: cargo fuzz run bytes -- -max_total_time=1800 # 30 minutes
+        # run for 30 minutes with a 2GB memory limit and a maximum input length of 2048 bytes
+        # the maximum input length is set so that the formatter's size limiter will prevent
+        # allocating more memory than the memory limit
+        run: cargo fuzz run bytes -- -max_total_time=1800 -rss_limit_mb=2048 -max_len=2048
 
   string:
     name: Fuzz string
@@ -46,4 +49,7 @@ jobs:
         run: cargo install cargo-fuzz
 
       - name: Fuzz
-        run: cargo fuzz run string -- -max_total_time=1800 # 30 minutes
+        # run for 30 minutes with a 2GB memory limit and a maximum input length of 2048 bytes
+        # the maximum input length is set so that the formatter's size limiter will prevent
+        # allocating more memory than the memory limit
+        run: cargo fuzz run string -- -max_total_time=1800 -rss_limit_mb=2048 -max_len=2048

--- a/fuzz/fuzz_targets/bytes.rs
+++ b/fuzz/fuzz_targets/bytes.rs
@@ -7,6 +7,8 @@ use mock::MockTime;
 
 fuzz_target!(|data: (MockTime, &[u8])| {
     let (time, format) = data;
+    let _ignored = strftime::bytes::strftime(&time, format, &mut buf[..]);
+
     // Give each fuzzer input a 16kb buffer to write to.
     let mut buf = vec![0u8; 16 * 1024].into_boxed_slice();
     let _ignored = strftime::buffered::strftime(&time, format, &mut buf[..]);

--- a/fuzz/fuzz_targets/bytes.rs
+++ b/fuzz/fuzz_targets/bytes.rs
@@ -7,7 +7,7 @@ use mock::MockTime;
 
 fuzz_target!(|data: (MockTime, &[u8])| {
     let (time, format) = data;
-    let _ignored = strftime::bytes::strftime(&time, format, &mut buf[..]);
+    let _ignored = strftime::bytes::strftime(&time, format);
 
     // Give each fuzzer input a 16kb buffer to write to.
     let mut buf = vec![0u8; 16 * 1024].into_boxed_slice();

--- a/fuzz/fuzz_targets/string.rs
+++ b/fuzz/fuzz_targets/string.rs
@@ -30,6 +30,8 @@ impl<'a> fmt::Write for LimitedBuf<'a> {
 
 fuzz_target!(|data: (MockTime, &str)| {
     let (time, format) = data;
+    let _ignored = strftime::string::strftime(&time, format, &mut buf[..]);
+
     // Give each fuzzer input a 16kb buffer to write to.
     let mut buf = vec![0u8; 16 * 1024].into_boxed_slice();
 

--- a/fuzz/fuzz_targets/string.rs
+++ b/fuzz/fuzz_targets/string.rs
@@ -30,7 +30,7 @@ impl<'a> fmt::Write for LimitedBuf<'a> {
 
 fuzz_target!(|data: (MockTime, &str)| {
     let (time, format) = data;
-    let _ignored = strftime::string::strftime(&time, format, &mut buf[..]);
+    let _ignored = strftime::string::strftime(&time, format);
 
     // Give each fuzzer input a 16kb buffer to write to.
     let mut buf = vec![0u8; 16 * 1024].into_boxed_slice();

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -787,6 +787,7 @@ impl<'t, 'f, T: CheckedTime> TimeFormatter<'t, 'f, T> {
 
         // Use a size limiter to limit the maximum size of the resulting
         // formatted string
+        // Ref: <https://github.com/ruby/ruby/blob/v3_4_2/strftime.c#L921-L928>
         let size_limit = self.format.len().saturating_mul(512 * 1024);
         let mut f = SizeLimiter::new(buf, size_limit);
 

--- a/src/tests/format.rs
+++ b/src/tests/format.rs
@@ -795,6 +795,11 @@ fn test_format_invalid() {
         let err = get_format_err(&time, format);
         assert!(matches!(err, Error::InvalidFormatString));
     }
+
+    for format in ["\0%", "\0%-4", "\0%-", "\0%-_"] {
+        let err = get_format_err(&time, format);
+        assert!(matches!(err, Error::InvalidFormatString));
+    }
 }
 
 #[test]


### PR DESCRIPTION
This patch improves the fuzzing harness by explicitly limiting memory usage and maximum input length to prevent out-of-memory (OOM) errors during fuzz testing. It sets an RSS limit of 2GB and restricts maximum input string length to 2048 bytes, ensuring that buffer allocations remain within safe limits defined by the formatter's internal size limiter.

Changes include:
- Setting `-rss_limit_mb=2048` and `-max_len=2048` for the fuzz targets in the GitHub Actions workflow.
- Adding explanatory comments to clarify these limits.
- Referencing MRI Ruby's `strftime.c` for the size limit calculation rationale.
- Enhancing fuzz target implementations to include calls to formatter methods to test input handling.
- Adding explicit test cases for invalid format strings containing embedded null bytes and incomplete format specifiers.

These improvements ensure that fuzzing effectively explores edge cases without triggering resource exhaustion, aligning the testing approach more closely with MRI Ruby's handling of large or invalid inputs.

Ref: https://github.com/ruby/ruby/blob/v3_4_2/strftime.c#L921-L928

See also https://github.com/artichoke/artichoke/issues/2840 which was opened as part of this investigation.

---

The input generated by the fuzzer which caused the OOM is 3238 bytes long and expands to ~1.5GB (1,471,087,884 bytes) before reaching the invalid specifier at the last byte. The current size limiter permits a max size of 1,697,644,544 bytes so this expansion is _just_ permissible.

<details>

<summary> Fuzzer failure </summary>

```
Failing input:

	fuzz/artifacts/string/oom-d13e14abcf7a02540cd7ae6bfaaef14bd754b1b4

Output of `std::fmt::Debug`:

	(
	    MockTime {
	        year: 0,
	        month: 9,
	        day: 9,
	        hour: 9,
	        minute: 0,
	        second: 0,
	        nanoseconds: 2559,
	        day_of_week: 0,
	        day_of_year: 0,
	        to_int: 3761688987579720960,
	        is_utc: false,
	        utc_offset: 875836468,
	        time_zone: "44",
	    },
	    "44444%%%%\0#%F%%F44444444544444%F%%\0$%%0F%44544444444444444%2%%%\0#%F2%\0%%%F%\0\u{2}\0%%0\0\0\0\0\0\u{1}%F%%\0%%0F%4\0\0\u{1}%F%%\0%%0F%4\n\n\0\t\t\t\t4\0\0\0\0\0\0\0\0\0\0\0\0\0\0~\0%%%\0\u{1}%F%%\0%%0F%44444444444544444%F%%\0%%0F%444444444444544444%F%%\0%%0F%44444445444444444%%%%\0#%F%%F%4440F%44544444444444444%2%%%\0#%F2%\0%%%F%\0\u{2}\0%%0\0\0\0\0\0\u{1}%F%%\0%%0F%4\0\0\u{1}%F%%\0%%0F%4\n\n\0\t\t\t\t4\0\0\0\0\0\0\0\0\0\0\0\0\0\0~\0%%%\0\u{1}%F%%\0%%0F%44444444444544444%F%%\0%%0F%444444444444544444%F%%\0%%0F%44444445444444444%%%%\0#%F%%F%44444444444544444%F%%\0%%0F%4444544444%F%%\0%%0F%44444444444444444%%%%\0#%F%%%\0%%F%\0\u{2}\0%%0\0\0\0\0\0\u{1}%F%%\0%%0F%44444444444544444%F%%\0%%0F%44444445444\0\0\0\0\0\0\0\0\0\0\0\0%%\0#%F%%F%4\n\n\0\t\t\t\t\0\0\0\0\0\0\0\0\0\0\0~\0%%%\0\u{1}%F%%\0%%0F%44444444444544444%F%%\0%%0F%444444444444544444%F%%%F%%\0-%0F%44444445444444444%%%%\0#%F-%F%44444444444544444%F%%\0%%0F%45\0\0\0\0%\0\u{1}F%%\0%%0F%44444444444544444%%0F%4444444544444\0#%F%%%\0%%44444444444%2%%%\0#%F2%\0%%%F%\0\u{2}\0%%0\0\0\0\0\0\u{1}%F%%\0%%0F%4\0\0\u{1}%F%%\0%%0F%4\n\n\0\t\t\t\t4\0\0\0\0\0\0\0\0\0\0\0\0\0\0~\0%%%\0\u{1}%F%%\0%%0F%44444444444544444%F%%\0%%0F%444444444444544444%F%%\0%%0F%44444445444444444%%%%\0#%F%%F%44444444444544444%F%%\0%%0F%4444544444%F%%\0%%0F%44444444444444444%%%%\0#%F%%%\0%%F%\0\u{2}\0%%0\0\0\0\0\0\u{1}%F%%\0%%0F%44444444444544444%F%%\0%%0F%44444445444\0\0\0\0\0\0\0\0\0\0\0\0%%\0#%F%%F%4\n\n\0\t\t\t\t\0\0\0\0\0\0\0\0\0\0\0~\0%%%\0\u{1}%F%%\0%%0F%44444444444544444%F%%\0%%0F%444444444444544444%F%%%F%%\0-%0F%44444445444444444%%%%\0#%F-%F%44444444444544444\0\0\0\0\0~\0%%%\0\u{1}%F%%\0%%0F%44444444444544444%F%%\0%%0F%444444444444544444%F%\0\0\04444%444444t5444\0\0\0\0\0\0\0\0\0\044444%%%%44%%%%\0#%F%%%\0%%F%\0\u{2}\0%%5\0\0\0\0%\0\u{1}F%%\0%%0F%44444444444544444%%0F%4444444544444\0#%F%%%\0%%444444444%%%F%\0%\0#%F%%F%444444444445%%\0%%0F%444\u{2}44445444444444%%%%\0w%F%%F%44444444444544445%F%%\0%%44444444444544444%F%%\0%%0F%44444445444\0\0\0\0\0\0\0\0\0\0\0\0%%\0#%F%%F%4\n\n\0\t\t\t\t\0\0\0\0\0\0\0\0\0\0\0~\0%%%\0\u{1}%F%%\0%%0F%44444444444544444%F%%\0%%0F%444444444444544444%F%%%F%%\0-%0F%44444445444444444%%%%\0#%F-%F%44444444444544444%F%%\0%%0F%4444544444%F%%\0%%0F%44444444444444444%%%%\0#%F%%%\0%%F%\0\u{2}\0%%0\0\0\0\0\0\u{1}%F%%\0%%0F%4444444444%444444t5444\0\0\0\0\0\0\0\0\0\044444%%%%44%%%%\0#%F%%%\0%%F%\0\u{2}\0%%5\0\0\0\0%\0\u{1}F%%\0%%0F%00000001024857295%%0F%4444444544444\0#%F%%%\0%%444444444%%%F44%%%F%\0%\0#%F%%F%444444444445%%\0%%0F%444\u{2}44445444444444%%%%\0w%F%%F%44444444444544445%F%%\0%%4444444444444%%%%\0\0-%0F%44444445444444444%%%%\0#%F-%F%44444444444544444%F%%\0%%0F%4444544444%F%%\0%%0F%44444444444444444%%%%\0#%F%%%\0%%F%\0\u{2}\0%%0\0\0\0\0\0\u{1}%F%%\0%%0F%4444444444%444444t5444\0\0\0\0\0\0\0\0\0\044444%%%44444444544444%F%%\0%%0F%4444544444%F%%\0%%0F%44444444444444444%%%%\0#%F%%%\0%%F%\0\u{2}\0%%0\0\0\0\0\0\u{1}%F%%\0%%0F%44444444444544444%F%%\0%%0F%44444445444\0\0\0\0\0\0\0\0\0\0\0\0%%\0#%F%%F%4\n\n\0\t\t\t\t\0\0\0\0\0\0\0\0\0\0\0~\0%%%\0\u{1}%F%%\0%%0F%44444444444544444%F%%\0%%0F%444444444444544444%F%%%F%%\0-%0F%44444445444444444%%%%\0#%F-%F%44444444444444444%444444t5444\0\0\0\0\0\0\0\0\0\044444%%%44444444544444%F%%\0%%0F%4444544444%F%%\0%%0F%44444444444444444%%%%\0#%F%%%\0%%F%\0\u{2}\0%%0\0\0\0\0\0\u{1}%F%%\0%%0F%44444444444544444%F%%\0%%0F%44444445444\0\0\0\0\0\0\0\0\0\0\0\0%%\0#%F%%F%4\n\n\0\t\t\t\t\0\0\0\0\0\0\0\0\0\0\0~\0%%%\0\u{1}%F%%\0%%0F%44444444444544444%F%%\0%%0F%444444444444544444%F%%%F%%\0-%0F%44444445444444444%%%%\0#%F-%F%44444444444544444%F%%\0%%0F%4444544444%F%%\0%%0F%44444444444444444%%%%\0#%F%%%\0%%F%\0\u{2}\0%%0\0\0\0\0\0\u{1}%F%%\0%%0FF%%\0%%0F%44444444444544444%%0F%4444444544444\0#%F%%%\0%%444444444%%%F%\0%\0#%F%%F%444444444445%%\0%%0F%444\u{2}44445444444444%%%%\0w%F%%F%44444444444544445%F%%\0%%4444444444444%%%%\0\0-%0F%44444445444444444%%%%\0#%F-%F%444444444%%%%\0#%F%%%\0%%F%",
	)
```

</details>