### PR TITLE
Address `clippy::unnecessary-semicolon` lint violation

### DIFF
--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -882,7 +882,7 @@ impl<'t, 'f, T: CheckedTime> TimeFormatter<'t, 'f, T> {
                     cursor.next();
                 }
                 _ => {}
-            };
+            }
         }
 
         // Parse spec

--- a/src/tests/rust_fmt_argument_max_padding.rs
+++ b/src/tests/rust_fmt_argument_max_padding.rs
@@ -104,7 +104,7 @@ fn test_format_specifiers_large_width_success() {
                 );
             }
             _ => panic!("Output not properly quoted for specifier '{spec}': {output}"),
-        };
+        }
     }
 }
 


### PR DESCRIPTION
Fixes CI failure on trunk with new rust stable https://github.com/artichoke/strftime-ruby/actions/runs/14346244360/job/40216512211